### PR TITLE
Fix #37 - Allow custom prefixes on method names

### DIFF
--- a/lib/rubypress/client.rb
+++ b/lib/rubypress/client.rb
@@ -58,12 +58,13 @@ module Rubypress
         :password => self.password
       }
       options_final.deep_merge!(options).each{|option| args.push(option[1]) if !option[1].nil?}
+      method = "wp.#{method}" unless method.include?('.')
       if self.debug
         connection.set_debug
-        server = self.connection.call("wp.#{method}", args)
+        server = self.connection.call(method, args)
         pp server
       else
-        self.connection.call("wp.#{method}", args)
+        self.connection.call(method, args)
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -11,6 +11,30 @@ describe "#client" do
     expect(CLIENT.execute("wp.getAuthors", {})).to eq( [{"user_id"=>"46917508", "user_login"=>"johnsmith", "display_name"=>"john"}, {"user_id"=>"33333367", "user_login"=>"johnsmith", "display_name"=>"johnsmith"}] )
   end
 
+  it "#execute adds wp prefix to bare method name" do
+    connection = CLIENT.connection
+    allow(connection).to receive(:call) do |method, args|
+      expect(method).to eq('wp.getAuthors')
+    end
+    CLIENT.execute("getAuthors", {})
+  end
+
+  it "#execute does not modify wp prefix on method name" do
+    connection = CLIENT.connection
+    allow(connection).to receive(:call) do |method, args|
+      expect(method).to eq('wp.getAuthors')
+    end
+    CLIENT.execute("wp.getAuthors", {})
+  end
+
+  it "#execute does not modify method with custom prefix" do
+    connection = CLIENT.connection
+    allow(connection).to receive(:call) do |method, args|
+      expect(method).to eq("wpx.getAuthors")
+    end
+    CLIENT.execute("wpx.getAuthors", {})
+  end
+
   it '#execute only sets up retries for the current instance' do
     retryable_connection = Rubypress::Client.new(CLIENT_OPTS.merge(retry_timeouts: true)).connection
     standard_connection = Rubypress::Client.new(CLIENT_OPTS).connection


### PR DESCRIPTION
This allows bare method names to be passed to Client#execute and be
prefixed by "wp." as before, but allows method names with a namespace
prefix to pass through unmodified. This is determined by whether or not
there is a '.' present in the method name.

This implementation does mean that custom methods must have some dotted
prefix, since any bare method names are assumed to need "wp.", but this
seems to be a reasonable requirement, matching API convention.