### PR TITLE
Add support for cookie based authentication mechanisms

### DIFF
--- a/lib/rubypress/client.rb
+++ b/lib/rubypress/client.rb
@@ -16,7 +16,7 @@ module Rubypress
 
     attr_reader :connection
     attr_accessor :port, :ssl_port, :host, :path, :username, :password, :use_ssl, :default_post_fields,
-                  :debug, :http_user, :http_password, :retry_timeouts
+                  :debug, :http_user, :http_password, :retry_timeouts, :cookie
 
     def initialize(options = {})
       {
@@ -31,7 +31,8 @@ module Rubypress
         :debug => false,
         :http_user => nil,
         :http_password => nil,
-        :retry_timeouts => false
+        :retry_timeouts => false,
+        :cookie => nil
       }.merge(options).each{ |opt| self.send("#{opt[0]}=", opt[1]) }
       self
     end
@@ -41,6 +42,7 @@ module Rubypress
         @connection = XMLRPC::Client.new(self.host, self.path, (self.use_ssl ? self.ssl_port : self.port),nil,nil,self.http_user,self.http_password,self.use_ssl,nil)
         @connection.http_header_extra = {'accept-encoding' => 'identity'}
         @connection.extend(XMLRPCRetryable) if retry_timeouts
+        @connection.cookie = self.cookie unless self.cookie.nil?
       end
      
       @connection

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -34,6 +34,18 @@ describe "#client" do
     expect { client.execute('newComment', {}) }.to raise_error(VCR::Errors::UnhandledHTTPRequestError)
   end
 
+  it "#connection does not include cookies by default" do
+    client = Rubypress::Client.new(CLIENT_OPTS)
+    connection = client.connection
+    expect(connection.cookie).to eq nil
+  end
+
+  it "#connection includes cookies when set" do
+    client = Rubypress::Client.new(CLIENT_OPTS.merge(cookie: "foo=bar"))
+    connection = client.connection
+    expect(connection.cookie).to include("foo=bar")
+  end
+
   it "#httpAuth" do
     conn = HTTP_AUTH_CLIENT.connection
 

--- a/spec/vcr_setup.rb
+++ b/spec/vcr_setup.rb
@@ -25,7 +25,7 @@ VCR.configure do |c|
     end
   end
   c.default_cassette_options = { match_requests_on: [:method] }
-  c.before_playback(:getUsersBlogs){|interaction|
-    interaction.response.headers['Content-Length'] = 711
+  c.before_playback(){|interaction|
+    interaction.response.update_content_length_header
   }
 end


### PR DESCRIPTION
I'd like to use rubypress with a wordpress instance that requires authentication, but does not support the basic authorization header. Instead, it requires the ability to pass a set of cookies. 

I have a set of changes in my fork, the [cookie-support](https://github.com/caseyhadden/rubypress/tree/cookie-support) branch. However, when I went to add tests, I get a lot of errors related to the response body size in the existing tests. So, I held off on an actual pull request. For example:

  2) #comments #getComments
     Failure/Error: CLIENT.getComments[0].should include("post_id" => post_id.to_s)
     RuntimeError:
       Wrong size. Was 2825, should be 2839

When I looked at the VCR cassette file ([getComments.yml](https://github.com/zachfeldman/rubypress/blob/master/spec/cassettes/getComments.yml)), some of this seems to be attributable to the formatting. If I  'line up' the &lt;/struct&gt;&lt;/value&gt; and other lines in the file, then the response size matches. I'm not well enough versed in VCR to know if this is the actual issue or not.

I'm happy to offer my branch as a pull request, but don't want to throw it over without tests. These same failures happen for me on the master branch, so I don't think it is anything I've done. I would also like to make sure that is the case by having the full suite run cleanly. 

Do you have any thoughts on whether these failures are expected or suggestions as to why I'm seeing them specifically? Thanks.