### PR TITLE
Catch 'Errno::EPIPE: Broken pipe' and reconnect.

### DIFF
--- a/lib/rubypress/xml_rpc_retryable.rb
+++ b/lib/rubypress/xml_rpc_retryable.rb
@@ -3,7 +3,8 @@ module Rubypress
     include Retryable
 
     RUBY_EXCEPTIONS = [
-      Timeout::Error
+      Timeout::Error,
+      Errno::EPIPE
     ]
 
     RUBY_EXCEPTIONS << Net::ReadTimeout if Net.const_defined?(:ReadTimeout)


### PR DESCRIPTION
I get this exception using the gem inside docker container using ruby 1.9.3p484 based on ubuntu 14.04.