### PR TITLE
Catch 'Errno::EPIPE: Broken pipe' and reconnect.

### DIFF
--- a/lib/rubypress/xml_rpc_retryable.rb
+++ b/lib/rubypress/xml_rpc_retryable.rb
@@ -3,7 +3,8 @@ module Rubypress
     include Retryable
 
     RUBY_EXCEPTIONS = [
-      Timeout::Error
+      Timeout::Error,
+      Errno::EPIPE
     ]
 
     RUBY_EXCEPTIONS << Net::ReadTimeout if Net.const_defined?(:ReadTimeout)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -52,6 +52,16 @@ describe "#client" do
     expect { client.execute('newComment', {}) }.to raise_error(Timeout::Error)
   end
 
+  it '#execute retries when catch broken pipe exception and retry_timeouts option is true' do
+    client = Rubypress::Client.new(CLIENT_OPTS.merge(retry_timeouts: true))
+    connection = client.connection
+    client.stub(:connection).and_return(connection)
+
+    expect(connection).to receive(:call_without_retry).twice.and_raise(Errno::EPIPE)
+    expect { client.execute('newComment', {}) }.to raise_error(Errno::EPIPE)
+  end
+
+
   it '#execute does not retry timeouts by default' do
     client = Rubypress::Client.new(CLIENT_OPTS)
     expect(client).to_not receive(:call_with_retry)


### PR DESCRIPTION
After two or three seconds of inactivity I get Catch 'Errno::EPIPE: Broken pipe'. After show error, the connection work fine again at the next execution. I add the exception  Errno::EPIPE to xml_rpc_retryable.rb RUBY_EXCEPTIONS array and include a test.

I got the exception ussing rubypress inside a docker container based on ubunbu 14:04 with ruby 1.9.3p484 installed with bundler rubypress (1.1.0).

Feel free for refactor the code. Regards and thanks for this great tool.