### PR TITLE
Add configurable timeouts

### DIFF
--- a/lib/rubypress/client.rb
+++ b/lib/rubypress/client.rb
@@ -16,7 +16,7 @@ module Rubypress
 
     attr_reader :connection
     attr_accessor :port, :ssl_port, :host, :path, :username, :password, :use_ssl, :default_post_fields,
-                  :debug, :http_user, :http_password, :retry_timeouts, :cookie
+                  :debug, :http_user, :http_password, :retry_timeouts, :timeout, :cookie
 
     def initialize(options = {})
       {
@@ -32,6 +32,7 @@ module Rubypress
         :http_user => nil,
         :http_password => nil,
         :retry_timeouts => false,
+        :timeout => 30,
         :cookie => nil
       }.merge(options).each{ |opt| self.send("#{opt[0]}=", opt[1]) }
       self
@@ -39,7 +40,7 @@ module Rubypress
 
     def connection
       if @connection.nil?
-        @connection = XMLRPC::Client.new(self.host, self.path, (self.use_ssl ? self.ssl_port : self.port),nil,nil,self.http_user,self.http_password,self.use_ssl,nil)
+        @connection = XMLRPC::Client.new(self.host, self.path, (self.use_ssl ? self.ssl_port : self.port),nil,nil,self.http_user,self.http_password,self.use_ssl,self.timeout)
         @connection.http_header_extra = {'accept-encoding' => 'identity'}
         @connection.extend(XMLRPCRetryable) if retry_timeouts
         @connection.cookie = self.cookie unless self.cookie.nil?

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -90,4 +90,16 @@ describe "#client" do
     expect( conn.password.nil? ).to be false
 
   end
+
+  it "#connection defaults the timeout to 30s" do
+    client = Rubypress::Client.new(CLIENT_OPTS)
+    connection = client.connection
+    expect(connection.timeout).to eq 30
+  end
+
+  it "#connection timeout can be overridden" do
+    client = Rubypress::Client.new(CLIENT_OPTS.merge(timeout: 60))
+    connection = client.connection
+    expect(connection.timeout).to eq 60
+  end
 end


### PR DESCRIPTION
@zachfeldman I found this useful for working with slow WordPress sites. Let me know if there's anything else I need to do to get it integrated.